### PR TITLE
Remove chmod() call that nulls permissions on new subdirectory

### DIFF
--- a/classes/processor.php
+++ b/classes/processor.php
@@ -480,7 +480,6 @@ class tool_coursearchiver_processor {
                 if (!mkdir($path, $CFG->directorypermissions, true)) {
                     throw new Exception('Archive path could not be created');
                 }
-                @chmod($path, $dirpermissions);
             }
 
             // Perform Backup.


### PR DESCRIPTION
I had trouble testing out the plugin because of this spurious chmod() call that had the effect of removing all permissions on the newly created sub-directory.