### PR TITLE
Fix: Moodle coding standards

### DIFF
--- a/classes/processor.php
+++ b/classes/processor.php
@@ -990,17 +990,17 @@ class tool_coursearchiver_processor {
                   FROM {course} c
              LEFT JOIN (
                         SELECT a.courseid, a.timeaccess
-                          FROM {user_lastaccess} as a
+                          FROM {user_lastaccess} a
                           JOIN (
                                 SELECT courseid, MAX(timeaccess) as timeaccess
-                                  FROM {user_lastaccess} as b
+                                  FROM {user_lastaccess} b
                               GROUP BY courseid
-                                ) AS b ON (
+                                ) b ON (
                                            a.courseid = b.courseid
                                            AND
                                            a.timeaccess = b.timeaccess
                                            )
-                       ) AS a ON c.id = a.courseid
+                       ) a ON c.id = a.courseid
                 WHERE c.id > 1 $searchsql
                 ORDER BY a.timeaccess";
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin = new stdClass();
-$plugin->version   = 2018081700;                // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2018081701;                // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2014111000;                // Requires this Moodle version.
 $plugin->component = 'tool_coursearchiver';     // Full name of the plugin (used for diagnostics).
 $plugin->release  = '3.5.1 (Build: 2016090200)';


### PR DESCRIPTION
Moodle coding standards: Never use AS keyword for table aliases
Table aliases with 'as' breaks Oracle queries on https://your.domain.com/admin/tool/coursearchiver/step2.php
e.g. with data:
[array (
'o_olderthan' => 1493622000,
'o_timeaccess' => 1493622000,
)]