### PR TITLE
Clarify what "MT" means in status

### DIFF
--- a/classes/tracker.php
+++ b/classes/tracker.php
@@ -405,8 +405,8 @@ class tool_coursearchiver_tracker {
         if ($this->outputmode == self::OUTPUT_CLI) {
             switch ($this->mode) {
                 case tool_coursearchiver_processor::MODE_COURSELIST:
-                    $cliicon = empty($data->visible) ? "hide " : "show ";
-                    $empty = $this->empty ? "MT " : "";
+                    $cliicon = empty($data->visible) ? "hide" : "show";
+                    $empty = $this->empty ? ";empty " : " ";
                     $date = get_string('never', 'tool_coursearchiver');
                     if (!empty($data->timeaccess)) {
                         $date = date("m/d/y", $data->timeaccess);


### PR DESCRIPTION
Clarify what "MT" means in status="hide MT " to show "hide;empty " instead.  I chose ; b/c it won't interfere with CSV formatting.  Removed the space b/t hide and MT b/c it makes converting to columns more difficult.